### PR TITLE
FHIR-58057: add server-side access token enforcement guidance

### DIFF
--- a/input/includes/link-list.md
+++ b/input/includes/link-list.md
@@ -42,6 +42,7 @@
 [Section 4.1.2.1 of RFC 6749]: https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1
 [Section 5 of RFC 6749]: https://datatracker.ietf.org/doc/html/rfc6749#section-5
 [Section 6 of RFC 6749]: https://datatracker.ietf.org/doc/html/rfc6749#section-6
+[Section 7 of RFC 6749]: https://datatracker.ietf.org/doc/html/rfc6749#section-7
 [Section 3.2.1 of RFC 7591]: https://datatracker.ietf.org/doc/html/rfc7591#section-3.2.1
 [Section 2.1 of RFC 8414]: https://datatracker.ietf.org/doc/html/rfc8414#section-2.1
 [Section 3.1.2.1 of OIDC Core]: https://openid.net/specs/openid-connect-core-1_0.html#AuthRequest

--- a/input/pagecontent/b2b.md
+++ b/input/pagecontent/b2b.md
@@ -315,13 +315,13 @@ For client applications using an authorization code grant, the Authorization Ser
 
 For all successful token requests, the Authorization Server **SHALL** issue access tokens with a lifetime no longer than 60 minutes.
 
+The Resource Server **SHALL** process access tokens as per [Section 7 of RFC 6749].
+
 <div class="stu-note" markdown="1">
 This guide does not currently constrain the type or format of access tokens issued by Authorization Servers. Note that other implementation guides (e.g. SMART App Launch, IUA, etc.), when used together with this guide, may limit the allowed access token types (e.g. Bearer) and/or formats (e.g. JWT).
 </div>
 
 #### Client application use of access tokens
-
-A FHIR Server **SHALL** only provide access to resources in a manner consistent with any assertions granted by the Authorization Server. For example, if the Authorization Server only granted read access to Patient resources, then the FHIR Server **SHALL NOT** return Observation resources in response to a request using that access token. This specification does not define how the FHIR Server assesses the assertions granted by the Authorization Server.
 
 A client application **SHALL** only use an access token in a manner consistent with any assertions made when requesting that token. For example, if a client asserted a `subject_id` and `purpose_of_use` in the B2B Authorization Extension Object included in its token request, then the access token granted in response to that request can only be used in that authorization context, i.e. for that requestor and for that purpose. If the same client application subsequently needs to retrieve a resource for a different requestor and/or for a different purpose from the same resource server, it cannot reuse the same access token. Instead, it must obtain a new access token by submitting another token request with an updated B2B Authorization Extension Object asserting the new authorization context.
 

--- a/input/pagecontent/b2b.md
+++ b/input/pagecontent/b2b.md
@@ -321,6 +321,8 @@ This guide does not currently constrain the type or format of access tokens issu
 
 #### Client application use of access tokens
 
+A FHIR Server **SHALL** only provide access to resources in a manner consistent with any assertions granted by the Authorization Server. For example, if the Authorization Server only granted read access to Patient resources, then the FHIR Server **SHALL NOT** return Observation resources in response to a request using that access token. This specification does not define how the FHIR Server assesses the assertions granted by the Authorization Server.
+
 A client application **SHALL** only use an access token in a manner consistent with any assertions made when requesting that token. For example, if a client asserted a `subject_id` and `purpose_of_use` in the B2B Authorization Extension Object included in its token request, then the access token granted in response to that request can only be used in that authorization context, i.e. for that requestor and for that purpose. If the same client application subsequently needs to retrieve a resource for a different requestor and/or for a different purpose from the same resource server, it cannot reuse the same access token. Instead, it must obtain a new access token by submitting another token request with an updated B2B Authorization Extension Object asserting the new authorization context.
 
 ### Refresh tokens

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -8,6 +8,7 @@ In addition to the tickets below, this version includes changes necessary to mov
 |---------|----------|
 |[FHIR-56931](https://jira.hl7.org/browse/FHIR-56931)|Move common requirements to a separate menu bar tab|
 |[FHIR-57937](https://jira.hl7.org/browse/FHIR-57937)|Clarify that complete redirection URIs are required for registraton|
+|[FHIR-58057](https://jira.hl7.org/browse/FHIR-58057)|Add server-side requirement that FHIR Servers only provide access consistent with assertions granted by the Authorization Server|
 
 ### Version 2.0.0
 

--- a/input/pagecontent/changelog.md
+++ b/input/pagecontent/changelog.md
@@ -8,7 +8,7 @@ In addition to the tickets below, this version includes changes necessary to mov
 |---------|----------|
 |[FHIR-56931](https://jira.hl7.org/browse/FHIR-56931)|Move common requirements to a separate menu bar tab|
 |[FHIR-57937](https://jira.hl7.org/browse/FHIR-57937)|Clarify that complete redirection URIs are required for registraton|
-|[FHIR-58057](https://jira.hl7.org/browse/FHIR-58057)|Add server-side requirement that FHIR Servers only provide access consistent with assertions granted by the Authorization Server|
+|[FHIR-58057](https://jira.hl7.org/browse/FHIR-58057)|Clarify Resource Server must process access tokens as per RFC 6749|
 
 ### Version 2.0.0
 


### PR DESCRIPTION
## Summary

This PR adds a server-side requirement to the access token guidance so that a FHIR Server is expected to provide access only in a manner consistent with assertions granted by the Authorization Server.

## Related ticket

- Jira: https://jira.hl7.org/browse/FHIR-58057